### PR TITLE
some bug fixes for opening existing watch face file in Mi-Create

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1516,6 +1516,8 @@ class MainWindow(QMainWindow):
         self.statusBar().addPermanentWidget(progressBar, 1)
 
         compileDirectory = os.path.join(os.path.dirname(currentProject["project"].dataPath), "output")
+        if not os.path.exists(compileDirectory): # if output folder does not exist
+            os.makedirs(compileDirectory)        # create new output folder
         output = []
 
         process = currentProject["project"].compile(currentProject["project"].dataPath, compileDirectory,

--- a/src/widgets/canvas.py
+++ b/src/widgets/canvas.py
@@ -328,16 +328,20 @@ class Canvas(QGraphicsView):
         # Add images
 
         bgImg = QPixmap()
-        bgImg.load(os.path.join(self.imageFolder, backgroundImage))
+        if backgroundImage is not None:        # check if there is a background image exist
+          bgImg.load(os.path.join(self.imageFolder, backgroundImage))
 
         hrImg = QPixmap()
-        hrImg.load(os.path.join(self.imageFolder, hourHandImage))
+        if hourHandImage is not None:
+          hrImg.load(os.path.join(self.imageFolder, hourHandImage))
 
         minImg = QPixmap()
-        minImg.load(os.path.join(self.imageFolder, minuteHandImage))
+        if minuteHandImage is not None:
+          minImg.load(os.path.join(self.imageFolder, minuteHandImage))
         
         secImg = QPixmap()
-        secImg.load(os.path.join(self.imageFolder, secondHandImage))
+        if secondHandImage is not None:        # check if there is a second hand image exist some AOD does not have this
+          secImg.load(os.path.join(self.imageFolder, secondHandImage))
 
         widget.addBackground(bgImg, itemAnchors["background"]["x"], itemAnchors["background"]["y"], interpolationStyle)
         widget.addHourHand(hrImg, itemAnchors["hour"]["x"], itemAnchors["hour"]["y"], interpolationStyle)
@@ -408,7 +412,8 @@ class Canvas(QGraphicsView):
 
     def createProgressArc(self, name, rect, zValue, backgroundImage, arcImage, arcX, arcY, radius, lineWidth, startAngle, endAngle, isFlat, snap, interpolationStyle):
         bgImage = QPixmap()
-        bgImage.load(os.path.join(self.imageFolder, backgroundImage))
+        if backgroundImage is not None:
+          bgImage.load(os.path.join(self.imageFolder, backgroundImage))
     
         fgImage = QPixmap()
         fgImage.load(os.path.join(self.imageFolder, arcImage))


### PR DESCRIPTION
1. Creates output folder if it does not exist 
2. Does not give an error if the analog clock widget does not have a second-hand image