### PR TITLE
Update plugin.py | UnicodeDecodeError

### DIFF
--- a/src/utils/plugin.py
+++ b/src/utils/plugin.py
@@ -41,7 +41,7 @@ class PluginLoader:
 
                 config_path = os.path.join(plugin_folder, "config.ini")
                 config = ConfigParser()
-                config.read_file(open(os.path.join(config_path)))
+                config.read_file(open(os.path.join(config_path), encoding="utf-8"))
                 
                 plugin_name = config.get("config", "name")
                 plugin_path = os.path.join(plugin_folder, config.get("config", "script"))
@@ -84,7 +84,7 @@ class PluginLoader:
         config_file = zipfile.Path(plugin_path, at='config.ini')
         
         config = ConfigParser()
-        config.read_file(config_file.open())
+        config.read_file(config_file.open(encoding="utf-8"))
     
         plugin_name = config.get("config", "name")
 


### PR DESCRIPTION
It may be only on my system but please test and merge it. 
this was the error -

Mi-Create-GMF-format-support-json-\src\utils\plugin.py", line 87, in installPlugin
    config.read_file(config_file.open())
  File "C:\Users\Pranav\AppData\Local\Programs\Python\Python312\Lib\configparser.py", line 705, in read_file
    self._read(f, source)
  File "C:\Users\Pranav\AppData\Local\Programs\Python\Python312\Lib\configparser.py", line 999, in _read
    for lineno, line in enumerate(fp, start=1):
                        ^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Pranav\AppData\Local\Programs\Python\Python312\Lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f in position 248: character maps to <undefined>