### PR TITLE
small bug fix, copying analog clock gives TypeError

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1074,13 +1074,13 @@ class WatchfaceEditor(QMainWindow):
             }
             widgetType = widgetData["widget"].getProperty("widget_type")
             if widgetType == "widget_analog":
-                if widgetData['widget'].data['@HourHand_ImageName'] != "":
+                if widgetData["widget"].getProperty("analog_hour_image") != "":
                     widgetData["images"].append(widgetData["widget"].getProperty("analog_hour_image"))
 
-                if widgetData['widget'].data['@MinuteHand_Image'] != "":
+                if widgetData["widget"].getProperty("analog_minute_image") != "":
                     widgetData["images"].append(widgetData["widget"].getProperty("analog_minute_image"))
                     
-                if widgetData['widget'].data['@SecondHand_Image'] != "":
+                if widgetData["widget"].getProperty("analog_second_image") != "":
                     widgetData["images"].append(widgetData["widget"].getProperty("analog_second_image"))
             
             elif widgetType == "widget_arc":

--- a/src/main.py
+++ b/src/main.py
@@ -1074,13 +1074,13 @@ class WatchfaceEditor(QMainWindow):
             }
             widgetType = widgetData["widget"].getProperty("widget_type")
             if widgetType == "widget_analog":
-                if widgetType["widget"].getProperty("analog_hour_image") != "":
+                if widgetData['widget'].data['@HourHand_ImageName'] != "":
                     widgetData["images"].append(widgetData["widget"].getProperty("analog_hour_image"))
 
-                if widgetType["widget"].getProperty("analog_minute_image") != "":
+                if widgetData['widget'].data['@MinuteHand_Image'] != "":
                     widgetData["images"].append(widgetData["widget"].getProperty("analog_minute_image"))
                     
-                if widgetType["widget"].getProperty("analog_second_image") != "":
+                if widgetData['widget'].data['@SecondHand_Image'] != "":
                     widgetData["images"].append(widgetData["widget"].getProperty("analog_second_image"))
             
             elif widgetType == "widget_arc":


### PR DESCRIPTION
I was getting this error when trying to copy the analog widget,  please check on your side if this issue arises.

>Traceback (most recent call last):
  File "Mi-Create\src\main.py", line 1077, in copySelectedWatchfaceWi    
if widgetType["widget"].getProperty("analog_hour_image") != "":
       ~~~~~~~~~~^^^^^^^^^^
TypeError: string indices must be integers, not 'str'