### PR TITLE
Update plugin_api/main.py | fix small bug when try to delete plugin

### DIFF
--- a/src/plugins/libs/plugin_api/main.py
+++ b/src/plugins/libs/plugin_api/main.py
@@ -36,4 +36,6 @@ class PluginAPI:
 
     def delete_library(self, library_name):
         libs_folder = os.path.join(self.plugin_loader.folder, "libs")
-        shutil.rmtree(os.path.join(libs_folder, library_name))
+        module_path = os.path.join(libs_folder, library_name)
+        if os.path.exists(module_path):
+            shutil.rmtree(module_path)


### PR DESCRIPTION
Sometimes it deletes entire folders in one run, like it removed `numpy/_core/*`.  
but in the next attempt, it tries to delete something within that already deleted folder, such as `numpy/_core/include/__init__.py`