### PR TITLE
Build on Mac OS X

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,7 @@ xmltodict
 requests
 
 pywin32; sys_platform == "win32"
+
+pyobjc-core; sys_platform == "darwin"
+pyobjc-framework-Cocoa; sys_platform == "darwin"
+pyobjc-framework-Quartz; sys_platform == "darwin"


### PR DESCRIPTION
Hi, a relatively new to Mac user here.

Since new versions of OS X comes with Python 3 by default (or did I get it via installing `xcode` dependencies?), the `pyobjc` package is not included right away. So I added some requirement to make the program run successfully.

Note that I was not tested if it works on Mac thoroughly, just try some basic feature. --- I'll keep update if there's more fix needed on Mac.

Sincerely,
neizod