### PR TITLE
Fix: fix for error SyntaxError: f-string: unmatched '['

### DIFF
--- a/src/utils/dialog.py
+++ b/src/utils/dialog.py
@@ -534,7 +534,7 @@ class CoreDialog(QDialog):
                 pluginDelete = QToolButton()
 
                 pluginName.setText(plugin["name"])
-                pluginLocation.setText(f"{plugin["author"]} • {plugin["version"]}")
+                pluginLocation.setText(f"{plugin['author']} • {plugin['version']}")
                 pluginLocation.setStyleSheet("color: palette(midlight)")
                 pluginDescription.setText(plugin["description"])
                 pluginDescription.setWordWrap(True)


### PR DESCRIPTION
Fix for the error with string formatting and double quotes

Traceback (most recent call last):
  File "Mi-Create\src\main.py", line 53, in <module>
    from utils.dialog import CoreDialog, MultiFieldDialog
  File "Mi-Create\src\utils\dialog.py", line 537
    pluginLocation.setText(f"{plugin["author"]} • {plugin["version"]}")
                                      ^^^^^^
SyntaxError: f-string: unmatched '['