### PR TITLE
Give main.py a shebang and mark as +x

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # Mi Create
 # ooflet <ooflet@proton.me>
 


### PR DESCRIPTION
Most python program main files these days have a shebang to tell your shell to execute it with a specific program, in this case `python3`. I've added that and marked it as executable so that now it can be run directly as `./src/main.py`